### PR TITLE
add check before calling `map` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class PostcssAssetWebpackPlugin {
 
       const promises = Object.keys(stats.assets).filter(name => path.extname(name) === '.css').map(name => {
         const css = stats.assets[name].source();
-        const map = stats.assets[name].map();
+        const map = typeof stats.assets[name].map === 'function' ? stats.assets[name].map() : undefined;
 
         return postcss(this.postcssOptions)
           .process(css, {from: name, to: name, map: {prev: map}})


### PR DESCRIPTION
fixes/workaround for nib-health-funds/postcss-asset-webpack-plugin#2